### PR TITLE
Add DB Vertrieb

### DIFF
--- a/js/parse_scripts.js
+++ b/js/parse_scripts.js
@@ -42,7 +42,7 @@ function preparseOperatorName(operator){
 	var operator=operator.toLowerCase();
 
 	//Operators
-	var DeutscheBahn = ['deutsche bahn', 'deutsche bahn ag', 'db', 'db ag', 'db bahn', 'dbag', 'db regio ag', 'db regio', 'db station&service', 'db station & service', 'db station&service ag', 'deutsche bahn (db)'];
+	var DeutscheBahn = ['deutsche bahn', 'deutsche bahn ag', 'db', 'db ag', 'db bahn', 'dbag', 'db regio ag', 'db regio', 'db station&service', 'db station & service', 'db station&service ag', 'deutsche bahn (db)', 'db vertrieb', 'db vertrieb gmbh'];
 	var DVB_to_fix = ['dvb ag', 'dvb', 'dresdner verkehrsbetriebe ag'];
 	var DVB_right = ['dresdner verkehrsbetriebe'];
 	var RNV = ['rnv', 'rhein-neckar-verkehr gmbh', 'rhein-neckar-verkehr'];


### PR DESCRIPTION
DB Vertrieb seems to be the official operator of Deutsche Bahn Fahrkartenautomaten, so therefore it should definetely be added to the list ;)
