### PR TITLE
Parse payment:cash according to https://wiki.osm.org/Key:payment:cash

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,12 @@
 						{
 							covered = EleValue;
 						}
+						if ((EleKey=="payment:cash"))
+						{
+							// Don't overwrite variables if already set
+							payment_coins = (payment_coins=="" ? EleValue : payment_coins);
+							payment_notes = (payment_notes=="" ? EleValue : payment_notes);
+						}
 						if ((EleKey=="payment:coins"))
 						{
 							payment_coins = EleValue;


### PR DESCRIPTION
Werte von `payment:coins` and `payment:notes` werden zum Wert von `payment:cash` gesetzt, sofern sie nicht als eigener Tag vorliegen.